### PR TITLE
feat(btcstaking): dynamic confirmation depth

### DIFF
--- a/proto/lorenzo/btcstaking/v1/params.proto
+++ b/proto/lorenzo/btcstaking/v1/params.proto
@@ -17,5 +17,6 @@ message Receiver {
 message Params {
   // receivers' name must be unique
   repeated Receiver receivers = 1;
+  // deprecated
   uint32 btc_confirmations_depth = 2;
 }

--- a/x/btcstaking/types/genesis.go
+++ b/x/btcstaking/types/genesis.go
@@ -44,8 +44,5 @@ func (gs GenesisState) Validate() error {
 		}
 		receivers[receiver.Name] = true
 	}
-	if gs.Params.BtcConfirmationsDepth == 0 {
-		return fmt.Errorf("btc confirmations depth cannot be 0")
-	}
 	return nil
 }

--- a/x/btcstaking/types/params.pb.go
+++ b/x/btcstaking/types/params.pb.go
@@ -24,7 +24,9 @@ var _ = math.Inf
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Receiver struct {
+	// name of the receiver
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// btc address
 	Addr string `protobuf:"bytes,2,opt,name=addr,proto3" json:"addr,omitempty"`
 	// like 0xBAb28FF7659481F1c8516f616A576339936AFB06
 	EthAddr string `protobuf:"bytes,3,opt,name=eth_addr,json=ethAddr,proto3" json:"eth_addr,omitempty"`
@@ -86,8 +88,10 @@ func (m *Receiver) GetEthAddr() string {
 
 // GenesisState defines the btcstaking module's genesis state.
 type Params struct {
-	Receivers             []*Receiver `protobuf:"bytes,1,rep,name=receivers,proto3" json:"receivers,omitempty"`
-	BtcConfirmationsDepth uint32      `protobuf:"varint,2,opt,name=btc_confirmations_depth,json=btcConfirmationsDepth,proto3" json:"btc_confirmations_depth,omitempty"`
+	// receivers' name must be unique
+	Receivers []*Receiver `protobuf:"bytes,1,rep,name=receivers,proto3" json:"receivers,omitempty"`
+	// deprecated
+	BtcConfirmationsDepth uint32 `protobuf:"varint,2,opt,name=btc_confirmations_depth,json=btcConfirmationsDepth,proto3" json:"btc_confirmations_depth,omitempty"`
 }
 
 func (m *Params) Reset()         { *m = Params{} }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced conditional checks based on different BTC amount thresholds to enforce depth requirements.

- **Deprecations**
  - Marked the `btc_confirmations_depth` field as deprecated.

- **Bug Fixes**
  - Removed outdated validation checks related to BTC confirmations depth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->