### PR TITLE
chore(ci): localnet docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,12 @@ install: go.sum
 build: go.sum
 	go build $(BUILD_FLAGS) -o build/lorenzod ./cmd/lorenzod
 
+.PHONY: clean
+clean:
+	rm -rf \
+	$(BUILDDIR)/ \
+	.testnets
+
 ###############################################################################
 ###                                E2E tests                                ###
 ###############################################################################
@@ -142,6 +148,20 @@ proto-check-breaking:
 	@echo "Checking Protobuf files for breaking changes"
 	$(protoImage) buf breaking --against $(HTTPS_GIT)#branch=main
 
+###############################################################################
+###                                Localnet                                 ###
+###############################################################################
+
+localnet-build-env:
+	$(MAKE) -C contrib/images lorenzod-env
+
+localnet-build-nodes:
+	$(DOCKER) run --rm -v $(CURDIR)/.testnets:/data lorenzo/lorenzod \
+			  testnet init-files --v 4 -o /data --starting-ip-address 192.168.10.2 --keyring-backend=test
+	docker-compose up -d
+
+localnet-stop:
+	docker-compose down
 ###############################################################################
 ###                                Releasing                                ###
 ###############################################################################

--- a/contrib/images/Makefile
+++ b/contrib/images/Makefile
@@ -1,0 +1,10 @@
+all: lorenzod-env
+
+lorenzod-env: lorenzod-rmi
+	docker build --tag lorenzo/lorenzod -f lorenzod-env/Dockerfile \
+		$(shell git rev-parse --show-toplevel)
+
+lorenzod-rmi:
+	docker rmi lorenzo/lorenzod 2>/dev/null; true
+
+.PHONY: all lorenzod-env lorenzod-rmi

--- a/contrib/images/lorenzod-env/Dockerfile
+++ b/contrib/images/lorenzod-env/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.20-alpine AS build
+
+RUN apk add build-base git linux-headers
+
+WORKDIR /work
+COPY go.mod go.sum /work/
+RUN go mod download
+
+COPY ./ /work
+RUN LEDGER_ENABLED=false make clean build
+
+
+FROM alpine AS run
+RUN apk add bash curl jq
+EXPOSE 26656 26657
+ENTRYPOINT ["/usr/bin/wrapper.sh"]
+CMD ["start", "--log_format", "plain"]
+STOPSIGNAL SIGTERM
+VOLUME /lorenzod
+WORKDIR /lorenzod
+
+COPY contrib/images/lorenzod-env/wrapper.sh /usr/bin/wrapper.sh
+COPY --from=build /work/build/lorenzod /lorenzod/

--- a/contrib/images/lorenzod-env/wrapper.sh
+++ b/contrib/images/lorenzod-env/wrapper.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+set -euo pipefail
+set -x
+
+BINARY=/lorenzod/${BINARY:-lorenzod}
+ID=${ID:-0}
+LOG=${LOG:-lorenzod.log}
+
+if ! [ -f "${BINARY}" ]; then
+	echo "The binary $(basename "${BINARY}") cannot be found. Please add the binary to the shared folder."
+	exit 1
+fi
+
+export LORENZODHOME="/data/node${ID}/lorenzod"
+
+if [ -d "$(dirname "${LORENZODHOME}"/"${LOG}")" ]; then
+  "${BINARY}" --home "${LORENZODHOME}" "$@" | tee "${LORENZODHOME}/${LOG}"
+else
+  "${BINARY}" --home "${LORENZODHOME}" "$@"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,57 +1,93 @@
-version: '3'
+version: "3"
 
 services:
-  node0:
+  lorenzonode0:
     container_name: lorenzonode0
-    image: "lorenzo/node"
+    image: "lorenzo/lorenzod"
+    environment:
+      - DEBUG=1
+      - ID=0
+      - LOG=${LOG:-lorenzod.log}
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
     ports:
       - "26656-26657:26656-26657"
+      - "1317:1317"
+      - "9090:9090"
+      - "2345:2345"
     volumes:
-      - ./build/node0/lorenzod:/lorenzo:Z
-    command: >
-      lorenzod start --home /lorenzo
+      - ./.testnets:/data:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.1
+        ipv4_address: 192.168.10.2
 
-  node1:
+  lorenzonode1:
     container_name: lorenzonode1
-    image: "lorenzo/node"
+    image: "lorenzo/lorenzod"
+    environment:
+      - DEBUG=0
+      - ID=1
+      - LOG=${LOG:-lorenzod.log}
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
     ports:
-      - "26659-26660:26656-26657"
+      - "26666-26667:26656-26657"
+      - "1318:1317"
+      - "9091:9090"
+      - "2346:2345"
     volumes:
-      - ./build/node1/lorenzod:/lorenzo:Z
-    command: >
-      lorenzod start --home /lorenzo
+      - ./.testnets:/data:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.2
+        ipv4_address: 192.168.10.3
 
-  node2:
+  lorenzonode2:
     container_name: lorenzonode2
-    image: "lorenzo/node"
+    image: "lorenzo/lorenzod"
+    environment:
+      - DEBUG=0
+      - ID=2
+      - LOG=${LOG:-lorenzod.log}
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
     ports:
-      - "26661-26662:26656-26657"
+      - "26676-26677:26656-26657"
+      - "1319:1317"
+      - "9092:9090"
+      - "2347:2345"
     volumes:
-      - ./build/node2/lorenzod:/lorenzo:Z
-    command: >
-      lorenzod start --home /lorenzo
+      - ./.testnets:/data:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.3
+        ipv4_address: 192.168.10.4
 
-  node3:
+  lorenzonode3:
     container_name: lorenzonode3
-    image: "lorenzo/node"
+    image: "lorenzo/lorenzod"
+    environment:
+      - DEBUG=0
+      - ID=3
+      - LOG=${LOG:-lorenzod.log}
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
     ports:
-      - "26663-26664:26656-26657"
+      - "26686-26687:26656-26657"
+      - "1320:1317"
+      - "9093:9090"
+      - "2348:2345"
     volumes:
-      - ./build/node3/lorenzod:/lorenzo:Z
-    command: >
-      lorenzod start --home /lorenzo
+      - ./.testnets:/data:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.4
+        ipv4_address: 192.168.10.5
 
 networks:
   localnet:
@@ -59,5 +95,4 @@ networks:
     ipam:
       driver: default
       config:
-        -
-          subnet: 192.167.10.0/24
+        - subnet: 192.168.10.0/25


### PR DESCRIPTION
Update our Docker Compose configuration. 

From now on, we can simply run `make localnet-build-env`, adjust the genesis file, and then run `make localnet-build-nodes` to start a local network with 4 validators on the localhost.