### PR TITLE
chore(ci): add release-binary action for github workflows

### DIFF
--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -11,7 +11,7 @@ permissions: write-all
 # via the 'make release' command.
 
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     environment: release
     steps:

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -1,0 +1,37 @@
+---
+name: Release Binary
+
+on:
+  release:
+    types: [created]
+
+permissions: write-all
+
+# This workflow creates a release using goreleaser
+# via the 'make release' command.
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+          check-latest: true
+
+      - name: release dry run
+        run: make release-dry-run
+
+      - name: setup release environment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
+
+      - name: release publish
+        run: make release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,104 @@
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: "lorenzod-darwin"
+    main: ./cmd/lorenzod
+    binary: bin/lorenzod
+    env:
+      - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    flags:
+      - -tags=cgo
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=lorenzo -X github.com/cosmos/cosmos-sdk/version.AppName=lorenzod -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "lorenzod-darwin-arm64"
+    main: ./cmd/lorenzod
+    binary: bin/lorenzod
+    env:
+      - CGO_ENABLED=1
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    flags:
+      - -tags=cgo
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=lorenzo -X github.com/cosmos/cosmos-sdk/version.AppName=lorenzod -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "lorenzod-linux"
+    main: ./cmd/lorenzod
+    binary: bin/lorenzod
+    env:
+      - CGO_ENABLED=1
+      - CC=gcc
+      - CXX=g++
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -tags=cgo
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=lorenzo -X github.com/cosmos/cosmos-sdk/version.AppName=lorenzod -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "lorenzod-linux-arm64"
+    main: ./cmd/lorenzod
+    binary: bin/lorenzod
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    goos:
+      - linux
+    goarch:
+      - arm64
+    flags:
+      - -tags=cgo
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=lorenzo -X github.com/cosmos/cosmos-sdk/version.AppName=lorenzod -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "lorenzod-windows"
+    main: ./cmd/lorenzod
+    binary: bin/lorenzod
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    goos:
+      - windows
+    goarch:
+      - amd64
+    flags:
+      - -tags=cgo
+      - -buildmode=exe
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=lorenzo -X github.com/cosmos/cosmos-sdk/version.AppName=lorenzod -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_{{ .Arch }}'
+    format_overrides:
+      - goos: windows
+        format: zip
+    builds:
+      - lorenzod-darwin
+      - lorenzod-darwin-arm64
+      - lorenzod-windows
+      - lorenzod-linux
+      - lorenzod-linux-arm64
+  
+checksum:
+  name_template: 'checksums.txt'
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+snapshot:
+  name_template: "{{ .Tag }}-next"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automated release process for the `lorenzod` application using GitHub Actions and goreleaser.
  - Configured multi-platform builds (darwin, linux, windows) for different architectures (amd64, arm64).
  - Added archive and checksum generation for releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->