### PR TITLE
fix(btcstaking): accept OP_PUSHDATA2/OP_PUSHDATA4 in OP_RETURN txout

### DIFF
--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -90,6 +90,10 @@ func ExtractPaymentToWithOpReturnId(tx *wire.MsgTx, addr btcutil.Address) (uint6
 				// to script iteslf i.e OP_RETURN + OP_PUSHDATA1 + len of bytes
 				if pkScript[1] == txscript.OP_PUSHDATA1 {
 					opReturnId = pkScript[3:]
+				} else if pkScript[1] == txscript.OP_PUSHDATA2 {
+					opReturnId = pkScript[4:]
+				} else if pkScript[1] == txscript.OP_PUSHDATA4 {
+					opReturnId = pkScript[6:]
 				} else {
 					// this should be one of OP_DATAXX opcodes we drop first 2 bytes
 					opReturnId = pkScript[2:]
@@ -187,7 +191,6 @@ func (ms msgServer) CreateBTCStaking(goCtx context.Context, req *types.MsgCreate
 
 	coins := []sdk.Coin{
 		{
-			// FIXME: no string literal
 			Denom:  types.NativeTokenDenom,
 			Amount: toMintAmount,
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced BTC staking functionality with improved handling for `OP_PUSHDATA2` and `OP_PUSHDATA4` cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->