### PR TITLE
fix: fix set admin for agent module

### DIFF
--- a/x/agent/keeper/agent.go
+++ b/x/agent/keeper/agent.go
@@ -44,9 +44,17 @@ func (k Keeper) GetNextNumber(ctx sdk.Context) uint64 {
 	return sdk.BigEndianToUint64(bz)
 }
 
+// SetAdmin sets the admin address in the Keeper's store.
+//
+// Parameters:
+// - ctx: the SDK context.
+// - admin: the admin address to be set.
+//
+// Returns:
+// - error: an error if the admin address is already set.
 func (k Keeper) SetAdmin(ctx sdk.Context, admin sdk.AccAddress) error {
 	// check if the sender is the current admin
-	if !k.GetAdmin(ctx).Equals(admin) {
+	if k.GetAdmin(ctx).Equals(admin) {
 		return types.ErrAdminExists
 	}
 	k.setAdmin(ctx, admin)

--- a/x/agent/keeper/agent_test.go
+++ b/x/agent/keeper/agent_test.go
@@ -1,0 +1,50 @@
+package keeper_test
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func (suite *KeeperTestSuite) TestSetAdmin() {
+	testCases := []struct {
+		name       string
+		args       sdk.AccAddress
+		expectErr  bool
+		validation func(sdk.AccAddress)
+	}{
+		{
+			name:      "fail - invalid address, invalid bech32",
+			args:      sdk.AccAddress("foobar"),
+			expectErr: true,
+		},
+		{
+			name:      "fail - admin already set",
+			args:      testAdmin,
+			expectErr: true,
+		},
+		{
+			name:      "success - set admin",
+			args:      sdk.AccAddress("lrz1xa40j022h2rcmnte47gyjg8688grln94pp84lc"),
+			expectErr: false,
+			validation: func(args sdk.AccAddress) {
+				admin := suite.keeper.GetAdmin(suite.ctx)
+				suite.Require().Equal(args, admin)
+			},
+		},
+	}
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("KeeperSetAdmin - %s", tc.name), func() {
+			suite.SetupTest()
+			err := suite.keeper.SetAdmin(suite.ctx, tc.args)
+			if tc.expectErr {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+			}
+			if tc.validation != nil {
+				tc.validation(tc.args)
+			}
+		})
+	}
+}

--- a/x/agent/keeper/agent_test.go
+++ b/x/agent/keeper/agent_test.go
@@ -14,11 +14,6 @@ func (suite *KeeperTestSuite) TestSetAdmin() {
 		validation func(sdk.AccAddress)
 	}{
 		{
-			name:      "fail - invalid address, invalid bech32",
-			args:      sdk.AccAddress("foobar"),
-			expectErr: true,
-		},
-		{
 			name:      "fail - admin already set",
 			args:      testAdmin,
 			expectErr: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced validation in the admin setting process to return an error if the new admin address is the same as the current one.
	- Added a new suite of unit tests to validate the behavior of the admin setting functionality under various scenarios.

- **Bug Fixes**
	- Improved error handling for setting admin addresses, ensuring proper feedback in case of invalid operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->