### PR TITLE
fix(plan): The validation should not pass when the string is an empty…

### DIFF
--- a/x/plan/types/msg.go
+++ b/x/plan/types/msg.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -60,7 +61,7 @@ func (m *MsgCreatePlan) ValidateBasic() error {
 	if !common.IsHexAddress(m.YatContractAddress) {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "invalid yat contract address")
 	}
-	if len(m.Name) == 0 {
+	if len(strings.TrimSpace(m.Name)) == 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "plan name cannot be empty")
 	}
 	if m.AgentId == 0 {
@@ -107,10 +108,10 @@ func (m *MsgCreateYAT) ValidateBasic() error {
 	if _, err := sdk.AccAddressFromBech32(m.Sender); err != nil {
 		return errorsmod.Wrap(err, "invalid sender address")
 	}
-	if len(m.Name) == 0 {
+	if len(strings.TrimSpace(m.Name)) == 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "yat name cannot be empty")
 	}
-	if len(m.Symbol) == 0 {
+	if len(strings.TrimSpace(m.Symbol)) == 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "yat symbol cannot be empty")
 	}
 	return nil

--- a/x/plan/types/msg_test.go
+++ b/x/plan/types/msg_test.go
@@ -161,6 +161,19 @@ func (suite *MsgsTestSuite) TestMsgCreatePlan() {
 			false,
 		},
 		{
+			"fail - plan name is empty space",
+			&types.MsgCreatePlan{
+				Name:               "  ",
+				PlanDescUri:        "https://lorenzo-protocol.io/lorenzo-stake-plan",
+				AgentId:            uint64(1),
+				PlanStartTime:      uint64(time.Now().UTC().Unix()) + 1000,
+				PeriodTime:         1000,
+				YatContractAddress: "0xbCC0CdF7683120a1965A343245FA602314C13b9A",
+				Sender:             "cosmos1qperwt9wrnkg5k9e5gzfgjppzpqhyav5j24d66",
+			},
+			false,
+		},
+		{
 			"fail - agent id cannot be zero",
 			&types.MsgCreatePlan{
 				Name:               "lorenzo-stake-plan",
@@ -305,10 +318,28 @@ func (suite *MsgsTestSuite) TestMsgCreateYAT() {
 			false,
 		},
 		{
+			"fail - yat name is empty space",
+			&types.MsgCreateYAT{
+				Name:   "  ",
+				Symbol: "LYAT",
+				Sender: "cosmos1qperwt9wrnkg5k9e5gzfgjppzpqhyav5j24d66",
+			},
+			false,
+		},
+		{
 			"fail - yat symbol cannot be empty",
 			&types.MsgCreateYAT{
 				Name:   "lorenzo-yat",
 				Symbol: "",
+				Sender: "cosmos1qperwt9wrnkg5k9e5gzfgjppzpqhyav5j24d66",
+			},
+			false,
+		},
+		{
+			"fail - yat symbol is empty space",
+			&types.MsgCreateYAT{
+				Name:   "lorenzo-yat",
+				Symbol: "  ",
 				Sender: "cosmos1qperwt9wrnkg5k9e5gzfgjppzpqhyav5j24d66",
 			},
 			false,


### PR DESCRIPTION
… string consisting of single or multiple spaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for `MsgCreatePlan` and `MsgCreateYAT` to prevent inputs with leading or trailing whitespace.
- **Bug Fixes**
	- Improved handling of whitespace-only inputs for the `Name` and `Symbol` fields, ensuring they are rejected as invalid.
- **Tests**
	- Added test cases for the `MsgCreatePlan` and `MsgCreateYAT` to verify the rejection of whitespace-only inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->