### PR TITLE
fix(upgrade): token module account not set 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,8 @@ format:
 ###                                Localnet                                 ###
 ###############################################################################
 
+PROPOSAL_FILE ?= "proposal.json"
+
 localnet-build-env:
 	$(MAKE) -C contrib/images lorenzod-env
 
@@ -283,6 +285,9 @@ localnet-stop:
 
 localnet-propose-upgrade:
 	$(MAKE) -C contrib/localnet propose-upgrade
+
+localnet-propose-general:
+	$(MAKE) -C contrib/localnet propose-general PROPOSAL_FILE=$$(realpath $(PROPOSAL_FILE))
 
 ###############################################################################
 ###                        Compile Solidity Contracts                       ###

--- a/app/upgrades/v200/upgrades.go
+++ b/app/upgrades/v200/upgrades.go
@@ -66,6 +66,10 @@ func upgradeHandlerConstructor(
 		tokenParams := tokentypes.DefaultParams()
 		app.TokenKeeper.SetParams(ctx, tokenParams)
 
+		if acc := app.AccountKeeper.GetModuleAccount(ctx, tokentypes.ModuleName); acc == nil {
+			panic("the token module account has not been set")
+		}
+
 		return app.ModuleManager.RunMigrations(ctx, c, fromVM)
 	}
 }

--- a/contrib/localnet/README.md
+++ b/contrib/localnet/README.md
@@ -1,0 +1,39 @@
+# Local Testnet Scrips
+
+Under this folder many scripts are used to help with the local testnet interaction.
+
+You should only use this scripts when local testnet is running.
+
+## Transaction
+
+Here are two snippets for the transaction. Copy and modify them as required to save effort.
+
+Execute on docker:
+
+```bash
+# Note by default user keyring folder is not mounted on docker.
+docker exec -it lorenzonode0 /lorenzod/lorenzod tx \
+      <command> \
+      --from node0 \
+      --chain-id lorenzo_83291-1 \
+      --gas 400000 \
+      --gas-prices 10alrz \
+      --keyring-backend test \
+      --home "/data/node0/lorenzod" \
+      --node "tcp://localhost:26657" \
+      --yes
+```
+
+Execute on host machine:
+
+```bash
+lorenzod tx \
+      <command> \
+      --from <user> \
+      --chain-id lorenzo_83291-1 \
+      --gas 400000 \
+      --gas-prices 10alrz \
+      --keyring-backend test \
+      --node "tcp://localhost:26657" \
+      --yes
+```

--- a/contrib/localnet/upgrade_proposal.json
+++ b/contrib/localnet/upgrade_proposal.json
@@ -4,9 +4,9 @@
       "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
       "authority": "lrz10d07y265gmmuvt4z0w9aw880jnsr700jq84749",
       "plan": {
-        "name": "v2.0",
+        "name": "",
         "time": "0001-01-01T00:00:00Z",
-        "height": "1443",
+        "height": "0",
         "info": "",
         "upgraded_client_state": null
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new variable for customizable proposal file paths in the local network management process.
  - Added a new target for proposing general upgrades within the local network.

- **Bug Fixes**
  - Enhanced the upgrade process by adding critical checks to ensure necessary module accounts are initialized before migrations.

- **Documentation**
  - Added a README file to guide users in executing transactions within a local testnet environment, including command examples and parameter specifications. 

- **Chores**
  - Updated the upgrade proposal configuration to remove the version name and reset the associated block height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->