### PR TITLE
feat(btcstaking/cli): replace ReceiverName with AgentId in btcstaking tx

### DIFF
--- a/x/btcstaking/client/cli/tx.go
+++ b/x/btcstaking/client/cli/tx.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/hex"
 	"fmt"
+	"strconv"
 
 	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -35,7 +36,7 @@ func GetTxCmd() *cobra.Command {
 
 func NewCreateBTCStakingWithBTCProofCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "btcstaking [btc_tx_bytes] [proof] [receiver_name]",
+		Use:   "btcstaking [btc_tx_bytes] [proof] [agent_id]",
 		Short: "Create a new btc staking request with proof from bitcoin-cli getrawtransaction&gettxoutproof output",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -46,6 +47,10 @@ func NewCreateBTCStakingWithBTCProofCmd() *cobra.Command {
 			txBytes, err := hex.DecodeString(args[0])
 			if err != nil {
 				return fmt.Errorf("failed to decode tx bytes: %w", err)
+			}
+			agentId, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				return fmt.Errorf("failed to parse agent id(%s): %w", args[2], err)
 			}
 			proofRaw, err := hex.DecodeString(args[1])
 			if err != nil {
@@ -82,8 +87,8 @@ func NewCreateBTCStakingWithBTCProofCmd() *cobra.Command {
 			blkHdrHashBytes.FromChainhash(&tmp)
 
 			msg := types.MsgCreateBTCStaking{
-				Receiver: args[2],
-				Signer:   clientCtx.GetFromAddress().String(),
+				AgentId: agentId,
+				Signer:  clientCtx.GetFromAddress().String(),
 				StakingTx: &types.TransactionInfo{
 					Key: &types.TransactionKey{
 						Index: txIndex,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the command-line interface for creating a Bitcoin staking request to now require an agent ID instead of a receiver name, improving clarity and functionality.
- **Bug Fixes**
	- Enhanced data handling in the CLI to ensure the agent ID is correctly parsed and utilized in the staking message construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->