### PR TITLE
fix: solve prune header bug

### DIFF
--- a/x/bnblightclient/client/cli/query.go
+++ b/x/bnblightclient/client/cli/query.go
@@ -115,7 +115,7 @@ func CmdQueryLatestHeader() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "latest-header",
 		Short: "query the latest header of the bnblightclient module",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 			queryClient := types.NewQueryClient(clientCtx)

--- a/x/bnblightclient/keeper/abci_test.go
+++ b/x/bnblightclient/keeper/abci_test.go
@@ -1,0 +1,65 @@
+package keeper_test
+
+import (
+	"github.com/Lorenzo-Protocol/lorenzo/v3/x/bnblightclient/testutil"
+)
+
+func (suite *KeeperTestSuite) TestEndBlock() {
+	headers := testutil.GetTestHeaders(suite.T())
+	testCases := []struct {
+		name           string
+		retainedBlocks uint64
+	}{
+		{
+			name:           "retained 1 blocks",
+			retainedBlocks: 1,
+		},
+		{
+			name:           "retained 2 blocks",
+			retainedBlocks: 2,
+		},
+		{
+			name:           "retained 3 blocks",
+			retainedBlocks: 3,
+		},
+		{
+			name:           "retained 4 blocks",
+			retainedBlocks: 4,
+		},
+		{
+			name:           "retained 5 blocks",
+			retainedBlocks: 5,
+		},
+		{
+			name:           "retained 6 blocks",
+			retainedBlocks: 6,
+		},
+		{
+			name:           "retained 10 blocks",
+			retainedBlocks: 10,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+			suite.Require().NoError(suite.keeper.UploadHeaders(suite.ctx, headers[5:]), "upload headers failed")
+
+			params := suite.keeper.GetParams(suite.ctx)
+			params.RetainedBlocks = tc.retainedBlocks
+			suite.Require().NoError(suite.keeper.SetParams(suite.ctx, params), "set params failed")
+
+			suite.keeper.EndBlock(suite.ctx)
+
+			// last header
+			idx := len(headers) - int(tc.retainedBlocks)
+			suite.Require().True(suite.keeper.HasHeader(suite.ctx, headers[idx].Number), "header not found")
+
+			idx--
+			if idx >= 0 {
+				suite.Require().False(suite.keeper.HasHeader(suite.ctx, headers[idx].Number), "header found")
+			}
+		})
+	}
+}

--- a/x/bnblightclient/keeper/prune.go
+++ b/x/bnblightclient/keeper/prune.go
@@ -30,7 +30,7 @@ func (k Keeper) pruneHeaders(ctx sdk.Context, pruneEndNumber uint64) {
 	for ; iterator.Valid(); iterator.Next() {
 		iterKey := iterator.Key()
 		number := sdk.BigEndianToUint64(iterKey[1:])
-		if number > pruneEndNumber {
+		if number <= pruneEndNumber {
 			header, exist := k.GetHeader(ctx, number)
 			if !exist {
 				continue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `latest-header` command can now be executed without any arguments, improving user accessibility.
  
- **Bug Fixes**
	- Enhanced the reliability of the `Keeper` component through a new test suite that verifies header management behavior.

- **Refactor**
	- Updated logic in the header pruning process to include previously excluded headers, potentially improving efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->